### PR TITLE
Set defaults for unset variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can either use a video that you host or one that is on YouTube.
 
 ##### Use your own video
 
-Add your video to the `static` folder and change `file` to the location of your video accordingly. Make sure you delete `youtubeId` or comment it out. 
+Add your video to the `static` folder and change `file` to the location of your video accordingly. Make sure you delete `youtubeId` or comment it out.
 
 ```toml
 [[params.visual.image]]
@@ -64,7 +64,7 @@ Add your video to the `static` folder and change `file` to the location of your 
 
 ##### Use a YouTube video
 
-Get the ID of the YouTube video and add it to `youtubeId`. Make sure you delete `file` or comment it out. 
+Get the ID of the YouTube video and add it to `youtubeId`. Make sure you delete `file` or comment it out.
 
 ```toml
 [[params.visual.image]]
@@ -105,15 +105,15 @@ This is what generates one link list:
 [[params.links]]
   [params.links.list1]
     heading = "Connect"
-  
+
     [[params.links.list1.link]]
       text = "Blog"
       url = "#"
-  
+
     [[params.links.list1.link]]
       text = "Email"
       url = "#"
-  
+
     [[params.links.list1.link]]
       text = "Newsletter"
       url = "#"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -9,7 +9,7 @@ disableKinds = ["page", "section", "taxonomy", "taxonomyTerm", "RSS", "sitemap",
 googleAnalytics = ""
 
 # Copyright
-copyright = "&copy;2017 Your Name"
+copyright = "&copy;2018 Your Name"
 
 [params]
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ default .Site.LanguageCode "en-US" }}">
 
 <head>
   {{ partial "head" . }}
@@ -11,7 +11,7 @@
 
     <!-- Image -->
     {{ if .Site.Params.visual.image.enable }}
-    
+
       <div class="split-image">
 
       </div>

--- a/layouts/partials/bio.html
+++ b/layouts/partials/bio.html
@@ -1,3 +1,5 @@
+{{ if .Site.Params.content.bio }}
 <div class="split-bio">
   <p>{{ .Site.Params.content.bio | markdownify }}</p>
 </div>
+{{ end }}

--- a/layouts/partials/links.html
+++ b/layouts/partials/links.html
@@ -2,7 +2,7 @@
 
   {{ range $key, $value := .Site.Params.links }}
     {{ range $key, $list := $value }}
-    
+
     {{ if $list.link }}
       <div class="split-list">
         <h3>{{ $list.heading }}</h3>


### PR DESCRIPTION
Set defaults for unset variables which prevented site from rendering, trim trailing spaces.
Fix https://github.com/christianmendoza/hugo-split-theme/issues/4.