### PR TITLE
Fix setting of LanguageCode in baseof.html

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ default .Site.LanguageCode "en-US" }}">
+<html lang="{{ .Site.LanguageCode | default "en-us" }}">
 
 <head>
   {{ partial "head" . }}


### PR DESCRIPTION
When setting the LanguageCode in config.toml now the right value will be set in the <html lang> tag.