### PR TITLE
Fix the README about the custom style.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Get the ID of the YouTube video and add it to `youtubeId`. Make sure you delete 
 Put custom css styles in static/css/style.css and enable this css in the config:
 
 ```toml
-[[params.custom.css]]
+[params.custom.css]
   enable = true
 ```
 


### PR DESCRIPTION
Using the provided example to include a custom css file results in this error when trying to serve the site:

```
Error: Error building site:
failed to render pages:
render of "home" failed:
execute of template failed:
template: index.html:5:5:
executing "index.html" at <partial "head" .>:
error calling partial: "/path/to/site/themes/hugo-split-theme/layouts/partials/head.html:27:11":
execute of template failed:
template: partials/head.html:27:11:
executing "partials/head.html" at <.Site.Params.custom.css.enable>:
can't evaluate field enable in type []map[string]interface {}
```

Using `[params.custom.css]` instead of `[[params.custom.css]]` solves this issue.
The custom file is included and no error occurs when serving the site.