### PR TITLE
Allow hiding of images and videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ Set `enable` to `true`. Add your image to the `static` folder and change `file` 
   position = "center center"
 ```
 
+You can control displaying of the image on a per-page basis by configuring `visual.image.enable` on each respective page's FrontMatter:
+
+```markdown
++++
+visual.image.enable = false
++++
+
+# Privacy statement
+```
 
 ### Use a video
 
@@ -84,6 +93,8 @@ First, disable the image by setting `enable` to `false` in `[params.visual.image
 Second, enable the video by setting `enable` to `true` in `[params.visual.video]`.
 
 You can either use a video that you host or one that is on YouTube.
+
+Just like with [an image](#use-an-image) you can not display a video altogether on particular pages by setting `visual.video.enable = false` in the page's FrontMatter.
 
 ##### Use your own video
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,14 +10,14 @@
   <div class="fs-split">
 
     <!-- Image -->
-    {{ if .Site.Params.visual.image.enable }}
+    {{ if .Params.visual.image.enable | default .Site.Params.visual.image.enable }}
 
       <div class="split-image">
 
       </div>
 
     <!-- Video -->
-    {{ else if .Site.Params.visual.video.enable }}
+    {{ else if .Params.visual.video.enable | default .Site.Params.visual.video.enable }}
 
       {{ partial "video" . }}
 

--- a/tests/exampleSiteWithImage/content/no-image.md
+++ b/tests/exampleSiteWithImage/content/no-image.md
@@ -1,0 +1,6 @@
++++
+title = "No image"
+visual.image.enable = false
++++
+
+Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Maecenas malesuada. Praesent congue erat at massa. Sed cursus turpis vitae tortor. Donec posuere vulputate arcu. Phasellus accumsan cursus velit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed aliquam, nisi quis porttitor congue, elit erat euismod orci, ac placerat dolor lectus quis orci.

--- a/tests/exampleSiteWithImage/urls.txt
+++ b/tests/exampleSiteWithImage/urls.txt
@@ -1,3 +1,4 @@
 http://hugo:1313/index.html
 http://hugo:1313/commonmark.html
 http://hugo:1313/long-text.html
+http://hugo:1313/no-image.html

--- a/tests/exampleSiteWithVideo/content/no-video.md
+++ b/tests/exampleSiteWithVideo/content/no-video.md
@@ -1,0 +1,6 @@
++++
+title = "No video"
+visual.video.enable = false
++++
+
+Curabitur ligula sapien, tincidunt non, euismod vitae, posuere imperdiet, leo. Maecenas malesuada. Praesent congue erat at massa. Sed cursus turpis vitae tortor. Donec posuere vulputate arcu. Phasellus accumsan cursus velit. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Sed aliquam, nisi quis porttitor congue, elit erat euismod orci, ac placerat dolor lectus quis orci.

--- a/tests/exampleSiteWithVideo/urls.txt
+++ b/tests/exampleSiteWithVideo/urls.txt
@@ -1,3 +1,4 @@
 http://hugo:1313/index.html
 http://hugo:1313/commonmark.html
 http://hugo:1313/long-text.html
+http://hugo:1313/no-video.html


### PR DESCRIPTION
This introduces the option to hide
videos or images on a per-page basis
by configuring the behavior in the
FrontMatter of a page.

Resolves #31