### PR TITLE
docs: add contributing notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# How to contribute to Split
+
+## Pull requests
+
+Please follow the [Conventional Commits 1.0.0 specification](https://www.conventionalcommits.org/en/v1.0.0/) to format your commit message. One commit per change is preferred.
+
+## Testing
+
+There are two test sites under [`tests/exampleSiteWithImage`](./tests/exampleSiteWithImage) and [`tests/exampleSiteWithVideo`](tests/exampleSiteWithVideo). Please adjust those accordingly
+to the changes you have made resp. check if your change didn't introduce any [regressions](https://en.wikipedia.org/wiki/Regression_testing).
+
+You can run these using the [`Makefile`](./Makefile) found at the root of this repository:
+
+`$ make hugo-server-example-site-with-image`\
+`$ make hugo-server-example-site-with-video`

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Now enter [`localhost:1313`](http://localhost:1313) in the address bar of your b
 
 ## Contributing
 
-Did you found a bug or got an idea for a new feature? Feel free to use the [issue tracker](https://github.com/escalate/hugo-split-theme/issues) to let me know. Or make directly a [pull request](https://github.com/escalate/hugo-split-theme/pulls).
+Did you found a bug or got an idea for a new feature? Feel free to use the [issue tracker](https://github.com/escalate/hugo-split-theme/issues) to let me know. Or make directly a [pull request](https://github.com/escalate/hugo-split-theme/pulls). See also the [Contributing](./CONTRIBUTING.md) notes.
 
 
 ## License


### PR DESCRIPTION
This adds a CONTRIBUTING.md file following
the GitHub conventions and explains how
to format commit messages and how to use
the tests / Makefile.