### PR TITLE
Tweaks for small screens

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -155,6 +155,11 @@ body.page-template-page-fullsingle-split {
     padding: 20px 0 0 0;
   }
 
+  @media (max-width: $bp-mobile) {
+    font-size: 16px;
+    line-height: 140%;
+  }
+
   p {
     color: $color-text;
     margin-bottom: 20px;

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -130,6 +130,11 @@ body.page-template-page-fullsingle-split {
 
   .tagline {
     color: $color-tagline;
+    line-height: 120%;
+
+    @media screen and (max-width: $bp-tablet) {
+      font-size: 42px;
+    }
   }
 
 }

--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -61,7 +61,7 @@ body.page-template-page-fullsingle-split {
     background-size:cover;
 
     @media (max-width: $bp-tablet ) {
-      height: 80vh;
+      max-height: 30vh;
       width: 100%;
     }
 


### PR DESCRIPTION
Hey, let's try again, the same tweaks as previously, this time applied to the SCSS files. Thanks for the commands to test the template, they were useful for comparing the Hugo port with the original template.

* Make the image landscape on narrow screens
* Reduce the size of tagline to visually match the original template
* Reduce the font size to visually match the original template