### PR TITLE
fix: remove min-height from `split-content`

### DIFF
--- a/assets/scss/_content.scss
+++ b/assets/scss/_content.scss
@@ -73,7 +73,6 @@ body.page-template-page-fullsingle-split {
 
   .split-content {
     width: 50%;
-    min-height: 100vh;
     display: flex;
     align-items: center;
       justify-content: center;


### PR DESCRIPTION
The max-height setting on `split-content` caused the container to be the same height as the viewport. In some situations this caused content to be moved downwards, sometimes partially below the fold. Removing max-height still keeps the content vertically centered, and eliminates the downward shift.